### PR TITLE
修復框架相容性問題和一些小吧葛

### DIFF
--- a/css/CE_CSS.css
+++ b/css/CE_CSS.css
@@ -119,6 +119,22 @@ button.active.ce-tab-favorite {
     background: rgba(255, 215, 0, 0.5);   /* active 更亮 */
 }
 
+#storyCaptionContent {
+    pointer-events: none;
+}
+
+#storyCaptionContent a,
+#storyCaptionContent button,
+#storyCaptionContent input,
+#storyCaptionContent select,
+#storyCaptionContent textarea,
+#storyCaptionContent label,
+#storyCaptionContent [onclick],
+#storyCaptionContent .link-internal,
+#storyCaptionContent .link-external {
+    pointer-events: auto;
+}
+
 /*用於顯示彈窗式ui上方按鈕*/
 .CEtab {
     border: 1px solid rgba(204,204,204,1);    

--- a/game/CE_cheatExtendedMenu.twee
+++ b/game/CE_cheatExtendedMenu.twee
@@ -2,9 +2,16 @@
 
 <!--用於顯示於左側狀態-->
 <<widget "CEstatebox">> 
-    <div id="CE_Toggle" class="dol-btn fit"><<CE_Toggle>></div>   
-    <div id="CEstatebox">	        
-        <<CE_UiLists>>
+    <<if $CE_hideCEToggleDisable is undefined>>
+        <<set $CE_hideCEToggleDisable to true>>
+    <</if>>
+    <<if !$CE_hideCEToggleDisable>>
+        <div id="CE_Toggle" class="dol-btn fit"><<CE_Toggle>></div>
+    <</if>>
+    <div id="CEstatebox" @style="$CE_hideCEToggleDisable ? 'display:none' : ''">
+        <<if !$CE_hideCEToggleDisable>>
+            <<CE_UiLists>>
+        <</if>>
 	</div>
 	<br>
 <</widget>>
@@ -188,4 +195,3 @@
     </div>    
     
 <</widget>>
-

--- a/scripts/CE_TimeTravelPlus.js
+++ b/scripts/CE_TimeTravelPlus.js
@@ -6,14 +6,27 @@ const TimeTravelAdapter = (() => {
 
     const LOG_PREFIX = '[cheat Extended][timeTrevel] ⏱️';
 
-    // 判斷遊戲是否有 Simple Framework
-    const hasSimpleFramework =
-        !!window.modUtils?.getAnyModByNameNoAlias?.('Simple Frameworks');
+    function hasSimpleFramework() {
+        return typeof TimeHandle !== 'undefined'
+            && typeof TimeHandle.timeTravel === 'function'
+            && !!window.modUtils?.getAnyModByNameNoAlias?.('Simple Frameworks');
+    }
 
-    console.info(
-        `${LOG_PREFIX} Adapter 初始化，框架模式：`,
-        hasSimpleFramework ? 'Simple Framework' : 'MapleBirch'
-    );
+    function mapleBirchTimeTravel(options) {
+        if (typeof window.maplebirchFrameworks?.timeTravel === 'function') {
+            return window.maplebirchFrameworks.timeTravel(options);
+        }
+        if (typeof window.maplebirch?.dynamic?.timeTravel === 'function') {
+            return window.maplebirch.dynamic.timeTravel(options);
+        }
+        if (typeof window.maplebirch?.state?.timeTravel === 'function') {
+            return window.maplebirch.state.timeTravel(options);
+        }
+
+        throw new Error('MapleBirch timeTravel API not found');
+    }
+
+    console.info(`${LOG_PREFIX} Adapter 初始化`);
 
     /* =====================================================
      * travelAbsolute
@@ -26,9 +39,9 @@ const TimeTravelAdapter = (() => {
             { year, month, day, hour, minute, second }
         );
 
-        if (!hasSimpleFramework) {
+        if (!hasSimpleFramework()) {
             // MapleBirch / DoL 原生呼叫
-            maplebirch.state.timeTravel({ year, month, day, hour, minute, second });
+            mapleBirchTimeTravel({ year, month, day, hour, minute, second });
             Engine.play(V.passage);
             return;
         }
@@ -100,9 +113,9 @@ const TimeTravelAdapter = (() => {
 
         console.info(`${LOG_PREFIX} 相對時間請求`, opts);
 
-        if (!hasSimpleFramework) {
+        if (!hasSimpleFramework()) {
             // MapleBirch 直接傳入
-            maplebirch.state.timeTravel(opts);
+            mapleBirchTimeTravel(opts);
             Engine.play(V.passage);
             return;
         }
@@ -116,7 +129,8 @@ const TimeTravelAdapter = (() => {
             month: Math.abs(Number(opts.addMonths) || 0),
             day:   Math.abs(Number(opts.addDays)   || 0),
             hour:  Math.abs(Number(opts.addHours)  || 0),
-            min:   Math.abs(Number(opts.addMinutes)|| 0)
+            min:   Math.abs(Number(opts.addMinutes)|| 0),
+            sec:   Math.abs(Number(opts.addSeconds)|| 0)
         };
 
         console.info(`${LOG_PREFIX} Simple Framework 相對時間呼叫`, { payload, backward });

--- a/scripts/CE_sideBarIcon.js
+++ b/scripts/CE_sideBarIcon.js
@@ -4,6 +4,19 @@ function CEiconClicked() {
 }
 window.CEiconClicked = CEiconClicked;
 
+function CE_renderSettings(wikiText) {
+    const target = document.getElementById('CE_settingsDiv') || window.CE_activeSettingsDiv;
+    if (!target) {
+        console.warn('[Cheat Extended] #CE_settingsDiv not found, skip render:', wikiText);
+        return false;
+    }
+
+    target.innerHTML = '';
+    new Wikifier(target, wikiText);
+    return true;
+}
+window.CE_renderSettings = CE_renderSettings;
+
 function CEiconSFdetect(){    
     const simpleMod = window.modUtils.getAnyModByNameNoAlias('Simple Frameworks'); // ⚡ Simple Frameworks
     const logger = window.modUtils.getLogger();
@@ -178,7 +191,7 @@ Macro.add('CE_CheatExtendedVersion', {
         restore() {
             let tabId = V.CE_LastTab;
             if (!tabId || !this._btnMap[tabId]) {
-                const firstTab = this.tabs.find(t => !t.condition || t.condition());
+                const firstTab = this.tabs.find(t => (!t.condition || t.condition()) && !V.CE_TabHidden?.[t.id]);
                 if (!firstTab) return;
                 tabId = firstTab.id;
             }
@@ -350,33 +363,33 @@ Macro.add('CE_CheatExtendedVersion', {
 
     // 註冊所有 tab
     const tabs = [
-        { id: 'quickTab', title: '左側快捷', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<swich>><</replace>>`) },
-        { id: 'teleport', title: '空間節點', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<swich_teleportation>><</replace>>`) },
-        { id: 'yanling', title: '言靈集', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<swich_yanling>><</replace>>`) },
-        { id: 'statControl', title: '狀態控制', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_statControlPanel>><</replace>>`) },
-        { id: 'purity', title: '純潔永駐', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_purityControl>><</replace>>`) },
-        { id: 'damage', title: '傷害倍數', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_damageMultiplier>><</replace>>`) },
-        { id: 'violence', title: '疼痛衰減', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_violenceControl>><</replace>>`) },
-        { id: 'hpap', title: 'HP、AP顯示', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<swich_HP_AP_display>><</replace>>`) },
-        { id: 'milk', title: '大量擠🥛模式', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<milk_released_setting>><</replace>>`) },
-        { id: 'semen', title: '大爆🐍模式', condition: () => V.player?.penisExist || V.debug, onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<semen_released_setting>><</replace>>`) },
-        { id: 'blackStore', title: '黑心商店', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<black_stores_setting>><</replace>>`) },
-        { id: 'money', title: '收支倍率調整', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_moneyCheat>><</replace>>`) },
-        { id: 'danceReward', title: '跳舞報酬加倍', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<dance_reward_setting>><</replace>>`) },
-        { id: 'brothelReward', title: '尋歡洞報酬加倍', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<brothel_basement_setting>><</replace>>`) },
-        { id: 'timeMultiplier', title: '時間流速控制', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_timeMultiplier>><</replace>>`) },
-        { id: 'timeTravel', title: '時空穿越', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_TimeTravelPlus>><</replace>>`) },
-        { id: 'debugMode', title: 'DEBUG MODE', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<swich_DEBUG_MODE>><</replace>>`) },
-        { id: 'study', title: '用功學習', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<study_hard_mod>><</replace>>`) },
-        { id: 'wardrobe', title: '大容量衣櫃', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<bigest_wardrobe_mod>><</replace>>`) },
-        { id: 'pcRepair', title: 'Pc縫衣中', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_autoRepairClothesUI>><</replace>>`) },
-        { id: 'allClothes', title: '一鍵添加所有服裝+', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_getAllClothes_new>><</replace>>`) },
-        { id: 'voidCreate', title: '虛空創造', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_inventory_helper>><</replace>>`) },
-        { id: 'magicCircuit', title: '魔術迴路', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_tattoo>><</replace>>`) },
-        { id: 'pcPreg', title: 'PC懷孕', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_Pregnancy>><</replace>>`) },
-        { id: 'parasitePreg', title: '寄生物懷孕控制', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<CE_parasiteControl>><</replace>>`) },
-        { id: 'autoWarm', title: '自動調溫', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<auto_clothes_Warmth>><</replace>>`) },
-        { id: 'quickYanling', title: '快速言靈', onClick: () => Wikifier.wikifyEval(`<<replace #CE_settingsDiv>><<quick_yanling>><</replace>>`) },
+        { id: 'quickTab', title: '左側快捷', onClick: () => CE_renderSettings('<<swich>>') },
+        { id: 'teleport', title: '空間節點', onClick: () => CE_renderSettings('<<swich_teleportation>>') },
+        { id: 'yanling', title: '言靈集', onClick: () => CE_renderSettings('<<swich_yanling>>') },
+        { id: 'statControl', title: '狀態控制', onClick: () => CE_renderSettings('<<CE_statControlPanel>>') },
+        { id: 'purity', title: '純潔永駐', onClick: () => CE_renderSettings('<<CE_purityControl>>') },
+        { id: 'damage', title: '傷害倍數', onClick: () => CE_renderSettings('<<CE_damageMultiplier>>') },
+        { id: 'violence', title: '疼痛衰減', onClick: () => CE_renderSettings('<<CE_violenceControl>>') },
+        { id: 'hpap', title: 'HP、AP顯示', onClick: () => CE_renderSettings('<<swich_HP_AP_display>>') },
+        { id: 'milk', title: '大量擠🥛模式', onClick: () => CE_renderSettings('<<milk_released_setting>>') },
+        { id: 'semen', title: '大爆🐍模式', condition: () => V.player?.penisExist || V.debug, onClick: () => CE_renderSettings('<<semen_released_setting>>') },
+        { id: 'blackStore', title: '黑心商店', onClick: () => CE_renderSettings('<<black_stores_setting>>') },
+        { id: 'money', title: '收支倍率調整', onClick: () => CE_renderSettings('<<CE_moneyCheat>>') },
+        { id: 'danceReward', title: '跳舞報酬加倍', onClick: () => CE_renderSettings('<<dance_reward_setting>>') },
+        { id: 'brothelReward', title: '尋歡洞報酬加倍', onClick: () => CE_renderSettings('<<brothel_basement_setting>>') },
+        { id: 'timeMultiplier', title: '時間流速控制', onClick: () => CE_renderSettings('<<CE_timeMultiplier>>') },
+        { id: 'timeTravel', title: '時空穿越', onClick: () => CE_renderSettings('<<CE_TimeTravelPlus>>') },
+        { id: 'debugMode', title: 'DEBUG MODE', onClick: () => CE_renderSettings('<<swich_DEBUG_MODE>>') },
+        { id: 'study', title: '用功學習', onClick: () => CE_renderSettings('<<study_hard_mod>>') },
+        { id: 'wardrobe', title: '大容量衣櫃', onClick: () => CE_renderSettings('<<bigest_wardrobe_mod>>') },
+        { id: 'pcRepair', title: 'Pc縫衣中', onClick: () => CE_renderSettings('<<CE_autoRepairClothesUI>>') },
+        { id: 'allClothes', title: '一鍵添加所有服裝+', onClick: () => CE_renderSettings('<<CE_getAllClothes_new>>') },
+        { id: 'voidCreate', title: '虛空創造', onClick: () => CE_renderSettings('<<CE_inventory_helper>>') },
+        { id: 'magicCircuit', title: '魔術迴路', onClick: () => CE_renderSettings('<<CE_tattoo>>') },
+        { id: 'pcPreg', title: 'PC懷孕', onClick: () => CE_renderSettings('<<CE_Pregnancy>>') },
+        { id: 'parasitePreg', title: '寄生物懷孕控制', onClick: () => CE_renderSettings('<<CE_parasiteControl>>') },
+        { id: 'autoWarm', title: '自動調溫', onClick: () => CE_renderSettings('<<auto_clothes_Warmth>>') },
+        { id: 'quickYanling', title: '快速言靈', onClick: () => CE_renderSettings('<<quick_yanling>>') },
 
         // 排序 UI 按鈕，不參與排序，只用於打開排序對話框
         { id: 'tabSort', title: '⚙️標籤頁管理', condition: () => V.CE_menuSortEnable || V.debug, onClick: () => CE_TabManager.openSortUI() }
@@ -406,6 +419,7 @@ Macro.add("title_cheatExtendedMenu", {
         // 3. 找到 overlay 的內容容器，保證後續操作有依附的 DOM
         const content = document.getElementById("customOverlayContent");
         if (!content) throw new Error("#customOverlayContent not found");
+        window.CE_activeSettingsDiv = document.getElementById('CE_settingsDiv');
 
         // 4. 確保 CE_TabManager 已存在
         if (window.CE_TabManager) {
@@ -499,6 +513,7 @@ Macro.add('cheat_extended', {
         contentDiv.id = 'CE_settingsDiv';
         contentDiv.className = 'no-numberify';
         contentWrapper.appendChild(contentDiv);
+        window.CE_activeSettingsDiv = contentDiv;
         main.appendChild(contentWrapper);
 
         container.appendChild(main);


### PR DESCRIPTION
## 摘要

修復 Cheat Extended 在 Lyra 整合包、白楓框架與簡易框架下的幾個相容性問題。

## 變更內容

- 新增安全渲染函式 `CE_renderSettings()`，避免設定區尚未掛載時直接 `<<replace #CE_settingsDiv>>` 報錯。
- 修復 Mods Cheats / Cheat Extended 選單在部分整合包中無法載入內容的問題。
- 更新時空穿越對白楓框架的呼叫方式，支援目前的 `maplebirchFrameworks.timeTravel` / `maplebirch.dynamic.timeTravel`，並保留舊 API fallback。
- 保留簡易框架的時間旅行支援，並補上相對時間中的秒數處理。
- 將左側狀態欄的 CE 操作面板預設隱藏，避免覆蓋或阻擋原本 sidebar。
- 調整 `#storyCaptionContent` 的 pointer-events，讓 sidebar 按鈕可正常點擊，同時保留內部互動元素可操作。

## 修復 Issues

- Fixes #13
- Fixes #14
- Fixes #15
- Fixes #16

## 測試

- `node --check scripts/CE_sideBarIcon.js`
- `node --check scripts/CE_TimeTravelPlus.js`
- `unzip -t cheat_extendedmod-fixed-issues-13-16.zip`
- 已手動測試白楓框架：sidebar 與 Cheat Extended 選單可正常點擊。

我是帥哥路人